### PR TITLE
New Request copy stewardship

### DIFF
--- a/local_modules/RequestFunds/Views/CreateRequestFormView.web.js
+++ b/local_modules/RequestFunds/Views/CreateRequestFormView.web.js
@@ -136,7 +136,7 @@ class CreateRequestFormView extends View
 		div.style.display = "block"
 		div.style.padding = "0 24px 0 24px"
 		{
-			const labelLayer = commonComponents_forms.New_fieldTitle_labelLayer("TO", self.context)
+			const labelLayer = commonComponents_forms.New_fieldTitle_labelLayer("RECEIVE MONERO AT", self.context)
 			div.appendChild(labelLayer)
 			//
 			const view = new WalletsSelectView({}, self.context)
@@ -207,7 +207,7 @@ class CreateRequestFormView extends View
 		div.style.paddingTop = "9px"
 		div.style.paddingBottom = "0"
 		{
-			const labelLayer = commonComponents_forms.New_fieldTitle_labelLayer("REQUEST FROM", self.context)
+			const labelLayer = commonComponents_forms.New_fieldTitle_labelLayer("REQUEST MONERO FROM", self.context)
 			labelLayer.style.float = "left"
 			div.appendChild(labelLayer)
 			//


### PR DESCRIPTION
The 'New Request' view presents a sticky UI problem. This may not be a perfect solution but the page title 'New Request' with simple 'To' and 'From' field titles below can feel strange. e.g. The new request is 'From' the creator of the request not the receiver of the request.

Here's an attempt to provide the user with a little more guidance.
