### PR TITLE
Add cloudflaredns to Content Security policy

### DIFF
--- a/local_modules/MainWindow/Views/index.browser.html
+++ b/local_modules/MainWindow/Views/index.browser.html
@@ -45,7 +45,7 @@
 			object-src 'none'; 
 			font-src 'self' https://js.intercomcdn.com/fonts/;  
 			img-src 'self' data: https://downloads.intercomcdn.com/i/o/  https://js.intercomcdn.com/images/ https://static.intercomassets.com/ https://www.google-analytics.com/r/collect https://stats.g.doubleclick.net/r/collect; 
-			connect-src 'self' https://api.mymonero.com:8443 https://api-iam.intercom.io data: blob:;">
+			connect-src 'self' https://api.mymonero.com:8443 https://api-iam.intercom.io https://cloudflare-dns.com data: blob:;">
 			<!-- script-src of unsafe-eval required to load wasm files at present but actual eval is disabled in renderer_setup_utils -->
 		<meta name="apple-itunes-app" content="app-id=1372508199">
 


### PR DESCRIPTION
Content Security Policy is a helpful header which allows to block bad requests that were not authorized from the app. For example, an attacker could try to inject scripts from xxx.com but the page will block this since there's content security policy.

Any API URL (for example to Cloudflare DNS - api for getting DNS records for OpenAlias) MUST be specified in Content Security Policy. Otherwise the OpenAlias feature does not work. The app can not fetch any DNS records.