### PR TITLE
chore: remove mas build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
       "category": "public.app-category.finance",
       "target": [
         "dmg",
-        "mas",
         "zip"
       ]
     },


### PR DESCRIPTION
Removing the mas build for mac currently as we are not able to get the build right with the current electron version.